### PR TITLE
Implement burn in LOTTO token

### DIFF
--- a/contracts/LOTTO.sol
+++ b/contracts/LOTTO.sol
@@ -8,8 +8,7 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 /// @notice 只有合约 Owner 有权限铸造（mint）新的 LOTTO 代币，初始总量为 0
 /// @dev 继承 OpenZeppelin 的 ERC20 和 Ownable，实现最简单的 mint 功能
 contract LOTTO is ERC20, Ownable {
-    /// @param name 代币名称，这里写 "LOTTO"
-    /// @param symbol 代币符号，这里写 "LOTTO"
+    /// @dev 构造函数固定名称和符号均为 "LOTTO"
     constructor() ERC20("LOTTO", "LOTTO") {
         // 部署时总量为 0，只有 owner 可以后续 mint 补充
     }
@@ -19,5 +18,15 @@ contract LOTTO is ERC20, Ownable {
     /// @param amount 铸造数量（最小单位，18 decimals）
     function mint(address to, uint256 amount) external onlyOwner {
         _mint(to, amount);
+    }
+
+    /// @notice 销毁指定地址的 LOTTO 代币
+    /// @param from 代币扣除地址
+    /// @param amount 销毁数量（最小单位，18 decimals）
+    function burn(address from, uint256 amount) external {
+        if (msg.sender != from) {
+            _spendAllowance(from, msg.sender, amount);
+        }
+        _burn(from, amount);
     }
 }


### PR DESCRIPTION
## Summary
- update constructor comment in `LOTTO.sol`
- implement a `burn` function allowing token holders or approved spenders to burn LOTTO

## Testing
- `npx hardhat compile` *(fails: 403 Forbidden for hardhat package)*

------
https://chatgpt.com/codex/tasks/task_e_6841454e0ae8832b8a16efcdb50a996e